### PR TITLE
The mafia no longer busts your kneecaps for daring to be 1% smaller

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -678,7 +678,7 @@
 	holder.update_transform()
 	var/danger = CONFIG_GET(number/threshold_body_size_slowdown)
 	if(features["body_size"] < danger)
-		var/slowdown = 1 + round(danger/features["body_size"], 0.1) * CONFIG_GET(number/body_size_slowdown_multiplier)
+		var/slowdown = (1 - round(features["body_size"] / danger, 0.1)) * CONFIG_GET(number/body_size_slowdown_multiplier)
 		holder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/small_stride, TRUE, slowdown)
 	else if(old_size < danger)
 		holder.remove_movespeed_modifier(/datum/movespeed_modifier/small_stride)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2313,16 +2313,17 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/min = CONFIG_GET(number/body_size_min)
 					var/max = CONFIG_GET(number/body_size_max)
 					var/danger = CONFIG_GET(number/threshold_body_size_slowdown)
-					var/new_body_size = input(user, "Choose your desired sprite size:\n([min*100]%-[max*100]%), Warning: May make your character look distorted[danger > min ? ", and an exponential slowdown will occur for those smaller than [danger*100]%!" : "!"]", "Character Preference", features["body_size"]*100) as num|null
+					var/new_body_size = input(user, "Choose your desired sprite size: ([min*100]%-[max*100]%)\nWarning: This may make your character look distorted[danger > min ? "! Additionally, a proportional movement speed penalty will be applied to characters smaller than [danger*100]%." : "!"]", "Character Preference", features["body_size"]*100) as num|null
 					if (new_body_size)
 						new_body_size = clamp(new_body_size * 0.01, min, max)
 						var/dorfy
-						if(danger > new_body_size)
-							dorfy = alert(user, "The chosen size appears to be smaller than the threshold of [danger*100]%, which will lead to an added exponential slowdown. Are you sure about that?", "Dwarfism Alert", "Yes", "Move it to the threshold", "No")
-							if(!dorfy || dorfy == "Move it above the threshold")
-								new_body_size = danger
+						if(new_body_size < danger)
+							dorfy = alert(user, "You have chosen a size below the slowdown threshold of [danger*100]%. For balancing purposes, the further you go below this percentage, the slower your character will be. Do you wish to keep this size?", "Speed Penalty Alert", "Yes", "Move it to the threshold", "No")
+						if(dorfy == "Move it to the threshold")
+							new_body_size = danger
 						if(dorfy != "No")
 							features["body_size"] = new_body_size
+					return
 
 		else
 			switch(href_list["preference"])

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -657,8 +657,9 @@ BODY_SIZE_MAX 1
 THRESHOLD_BODY_SIZE_SLOWDOWN 0.85
 
 ## Multiplier used in the smaller strides slowdown calculation.
+## This is a linear function that smoothly intensifies as the player size decreases below the above threshold.
 ## Doesn't apply to floating or crawling mobs.
-BODY_SIZE_SLOWDOWN_MULTIPLIER 0.25
+BODY_SIZE_SLOWDOWN_MULTIPLIER 3
 
 ## Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.
 ALLOW_CUSTOM_SKINTONES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, being 1% smaller than the sprite size threshold causes your character to suddenly be slam-dunked with a debuff that cuts their speed in half. This fixes that.

**This is not a balance change.** This PR fixes a broken formula that does not do what it says it does, and changes it to something that can be more easily rebalanced as staff sees fit. 

The current equation used is `1 + [slowdown threshold (85%)] / [body size] * [slowdown multiplier (.25)]`. This means that any size between 150% - 86% receives no speed changes, but as soon as you hit 85%, your speed is more or less halved. Furthermore, there is no noticeable difference in speed between 85% - 60%, making it more advantageous to choose the smallest size if you're already at the threshold. This slowdown is definitely not exponential, despite what it says. No amount of config value adjustments can fix this broken formula, hence why this PR was made.

See the screen captures below for proof (For reference, all clips are exactly 7 seconds long):
86% size (no slowdown) - https://i.gyazo.com/cc1a99fb414b7cf7ebb1a0e89fee1f79.mp4
85% size  (massive slowdown) - https://i.gyazo.com/49a6d7b800fdb99edb01d7d60d238d2f.mp4
60% size  (barely any difference) - https://i.gyazo.com/8fa486f265b531cdae899b45e96a7276.mp4

The new equation is `(1 - [body size] / [slowdown threshold (85%)]) * [slowdown multiplier (3)]`. There is no slowdown applied until you're below the threshold, and then a speed penalty is gradually applied, which increases the smaller the character gets, up to a maximum of the slowdown multiplier. **The `BODY_SIZE_SLOWDOWN_MULTIPLIER` needs to be changed in the `game_options.txt` config file**, assuming merging this does not change it. The current value of .25 will not work well with this new equation; in my testing, 3 is a good value to have it at, but staff are free to balance it however they please.

I also reworded some text to make things more clear for the player, fixed a button that didn't work, and did some cleanup.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes a poorly-written formula that failed to accomplish its intended goal, and makes it easier for server owners to balance the speed penalty for small sprites. Also fixes some smaller bugs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed the slowdown formula for small character sprites; no more jarring slowdown at threshold and you now actually get slower as you go further below the threshold.
fix: Fixed the "Move it to the threshold" button; it now does what it says.
tweak: Reworded some text to be clearer.
config: Changed the default BODY_SIZE_SLOWDOWN_MULTIPLIER from 0.25 to 3 in the config to adjust for the new formula. Let the appropriate staff know if small characters should be slower or faster; only they can change this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
